### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: python
+
+jobs:
+  include:
+    - python: 3.6
+    - python: 3.7
+
+before_install:
+  - |
+    set -e
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+        arch="Linux"
+    elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        arch="MacOSX"
+    else
+        echo "Unknown arch $TRAVIS_OS_NAME"
+        exit 1
+    fi
+    wget https://repo.continuum.io/miniconda/Miniconda3-latest-${arch}-x86_64.sh -O miniconda.sh
+    chmod +x miniconda.sh
+    ./miniconda.sh -b -p ~/mc
+    source ~/mc/etc/profile.d/conda.sh
+    conda update conda --yes
+
+install:
+  - export GIT_FULL_HASH=`git rev-parse HEAD`
+  - conda create -n covid19 -c nsls2forge -c conda-forge python=$TRAVIS_PYTHON_VERSION openbabel autodock
+  - conda activate covid19
+  - conda install -c nsls2forge mgltools
+  - conda list
+  - pip list
+
+script:
+  - |
+    set -e
+    cd ProcessingScripts/
+    ./example.sh
+    echo "CC(C[C@@H](B(O)O)NC(=O)[C@@H](NC(=O)c1cnccn1)Cc1ccccc1)C DB-84" > ena+db-small.can
+    ./example.sh
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
 script:
   - |
     set -e
+    ulimit -s unlimited
     cd ProcessingScripts/
     ./example.sh
     echo "CC(C[C@@H](B(O)O)NC(=O)[C@@H](NC(=O)c1cnccn1)Cc1ccccc1)C DB-84" > ena+db-small.can

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ before_install:
 
 install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
-  - conda create -n covid19 -c nsls2forge -c conda-forge python=$TRAVIS_PYTHON_VERSION openbabel autodock
+  - conda create -y -n covid19 -c nsls2forge -c conda-forge python=$TRAVIS_PYTHON_VERSION openbabel autodock
   - conda activate covid19
-  - conda install -c nsls2forge mgltools
+  - conda install -y -c nsls2forge mgltools
   - conda list
   - pip list
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ install:
   - conda install -y -c nsls2forge mgltools
   - conda list
   - pip list
+  - python -VV
+  - python3 -VV
 
 script:
   - |


### PR DESCRIPTION
Here is the configuration for Travis-CI. This will perform a basic test with 2 configuration - one with the existing `ena+db-small.can`, and another one with the DB-84 config (which causes an error with the default installation, but has a fix in the [autodock](https://anaconda.org/nsls2forge/autodock/files) package from the [nsls2forge](https://anaconda.org/nsls2forge) channel).

To enable it, these instructions can be useful: https://nsls-ii.github.io/scientific-python-cookiecutter/ci.html#activate-travis-ci-for-your-github-repository.