### PR TITLE
CI: more test examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,13 @@ script:
     set -e
     ulimit -s unlimited
     cd ProcessingScripts/
+    # Test a standard example:
     ./example.sh
+
+    # Test the fix for the AD4_parameters.dat:
     echo "CC(C[C@@H](B(O)O)NC(=O)[C@@H](NC(=O)c1cnccn1)Cc1ccccc1)C DB-84" > ena+db-small.can
     ./example.sh
 
+    # Test the fix for the "unknown W# atom type" issue:
+    echo "Nc1nc2NC3OC4COP(=O)([O-])O[Mg]OP(=O)(OCC5C6=C(S[W]7(SC(=C4S7)C3Nc2c(=O)[nH]1)S6)C1Nc2c(NC1O5)nc([nH]c2=O)N)[O-] DB-1573" > ena+db-small.can
+    ./example.sh


### PR DESCRIPTION
Here is an update for the Travis CI configuration to include more test examples which were failing previously. The build logs can be found at https://travis-ci.org/github/mrakitin/DataCrunching/builds/672058573.