### PR TITLE
CI: add a test for Chromium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,13 @@ install:
   - python -VV
   - python3 -VV
   - obabel -V
-  - autodock4 --version && autogrid --version
+  - ulimit -s unlimited && autodock4 --version && autogrid --version
   - pythonsh --help
 
 script:
   - |
     set -e
-    # Unlimit stack size to avoid openbabel crashes.
+    # Unlimit stack size to avoid autodock crashes.
     ulimit -s unlimited
     cd ProcessingScripts/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - python -VV
   - python3 -VV
   - obabel -V
-  - ulimit -s unlimited && autodock4 --version && autogrid --version
+  - ulimit -s unlimited && autodock4 --version && autogrid4 --version
   - pythonsh --help
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,6 @@ script:
         echo "$CALC_ENTRY" > ena+db-small.can
     fi
 
+    cat ena+db-small.can
+
     ./example.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,7 @@ script:
     # Test the fix for the "unknown W# atom type" issue:
     echo "Nc1nc2NC3OC4COP(=O)([O-])O[Mg]OP(=O)(OCC5C6=C(S[W]7(SC(=C4S7)C3Nc2c(=O)[nH]1)S6)C1Nc2c(NC1O5)nc([nH]c2=O)N)[O-] DB-1573" > ena+db-small.can
     ./example.sh
+
+    # Test the missing Cr atom from AD4_parameters.dat:
+    echo "[O-][51Cr](=O)(=O)[O-] DB-10072" > ena+db-small.can
+    ./example.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,15 +36,24 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda create -y -n covid19 -c nsls2forge -c conda-forge python=$TRAVIS_PYTHON_VERSION openbabel autodock
   - conda activate covid19
+  # The following step needs to be performed separately as it installs
+  # Python 2.5 and replaces environment's python executable (we expect it), so
+  # that the 'pythonsh' tool works correctly. For other purposes, 'python3'
+  # should be used.
   - conda install -y -c nsls2forge mgltools
+  - env | sort -u
   - conda list
   - pip list
   - python -VV
   - python3 -VV
+  - obabel -V
+  - autodock4 --version && autogrid --version
+  - pythonsh --help
 
 script:
   - |
     set -e
+    # Unlimit stack size to avoid openbabel crashes.
     ulimit -s unlimited
     cd ProcessingScripts/
 
@@ -52,6 +61,9 @@ script:
         echo "$CALC_ENTRY" > ena+db-small.can
     fi
 
+    echo -e "The contents of 'ena+db-small.can':"
+    python3 -c "print('=' * 80)"
     cat ena+db-small.can
+    python3 -c "print('=' * 80, '\n')"
 
     ./example.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,18 @@ language: python
 
 jobs:
   include:
-    - python: 3.6
-    - python: 3.7
+    - name: "Test a standard example"
+      python: 3.7
+      env: CALC_ENTRY=
+    - name: "Test the fix for the AD4_parameters.dat"
+      python: 3.7
+      env: CALC_ENTRY="CC(C[C@@H](B(O)O)NC(=O)[C@@H](NC(=O)c1cnccn1)Cc1ccccc1)C DB-84"
+    - name: "Test the fix for the 'unknown W# atom type' issue"
+      python: 3.7
+      env: CALC_ENTRY="Nc1nc2NC3OC4COP(=O)([O-])O[Mg]OP(=O)(OCC5C6=C(S[W]7(SC(=C4S7)C3Nc2c(=O)[nH]1)S6)C1Nc2c(NC1O5)nc([nH]c2=O)N)[O-] DB-1573"
+    - name: "Test the missing Cr atom from AD4_parameters.dat"
+      python: 3.7
+      env: CALC_ENTRY="[O-][51Cr](=O)(=O)[O-] DB-10072"
 
 before_install:
   - |
@@ -37,17 +47,9 @@ script:
     set -e
     ulimit -s unlimited
     cd ProcessingScripts/
-    # Test a standard example:
-    ./example.sh
 
-    # Test the fix for the AD4_parameters.dat:
-    echo "CC(C[C@@H](B(O)O)NC(=O)[C@@H](NC(=O)c1cnccn1)Cc1ccccc1)C DB-84" > ena+db-small.can
-    ./example.sh
+    if [ ! -z "$CALC_ENTRY" ]; then
+        echo "$CALC_ENTRY" > ena+db-small.can
+    fi
 
-    # Test the fix for the "unknown W# atom type" issue:
-    echo "Nc1nc2NC3OC4COP(=O)([O-])O[Mg]OP(=O)(OCC5C6=C(S[W]7(SC(=C4S7)C3Nc2c(=O)[nH]1)S6)C1Nc2c(NC1O5)nc([nH]c2=O)N)[O-] DB-1573" > ena+db-small.can
-    ./example.sh
-
-    # Test the missing Cr atom from AD4_parameters.dat:
-    echo "[O-][51Cr](=O)(=O)[O-] DB-10072" > ena+db-small.can
     ./example.sh


### PR DESCRIPTION
A test for `Cr`. Requires the latest autodock version:
```
  autodock                                 4.2.6-he1b5a44_3 --> 4.2.6-he1b5a44_4
```

I think we should make the CI enabled as soon as possible. Then we should add the failing test cases first, and have a fix in the packages after that, so it will be the "before/after" comparison.

Closes #5.